### PR TITLE
msm8960: Adapt loc_agps_open_with_apniptype from newer devices

### DIFF
--- a/msm8960/loc_api/libloc_api_50001/loc.cpp
+++ b/msm8960/loc_api/libloc_api_50001/loc.cpp
@@ -90,15 +90,17 @@ static int  loc_agps_open(const char* apn);
 static int  loc_agps_closed();
 static int  loc_agps_open_failed();
 static int  loc_agps_set_server(AGpsType type, const char *hostname, int port);
+static int  loc_agps_open_with_apniptype( const char* apn, ApnIpType apnIpType);
 
-static const AGpsInterface_v1 sLocEngAGpsInterface =
+static const AGpsInterface sLocEngAGpsInterface =
 {
-   sizeof(AGpsInterface_v1),
+   sizeof(AGpsInterface),
    loc_agps_init,
    loc_agps_open,
    loc_agps_closed,
    loc_agps_open_failed,
-   loc_agps_set_server
+   loc_agps_set_server,
+   loc_agps_open_with_apniptype
 };
 
 static int loc_xtra_init(GpsXtraCallbacks* callbacks);
@@ -657,6 +659,50 @@ static int loc_agps_open(const char* apn)
     ENTRY_LOG();
     AGpsType agpsType = AGPS_TYPE_SUPL;
     AGpsBearerType bearerType = AGPS_APN_BEARER_IPV4;
+    int ret_val = loc_eng_agps_open(loc_afw_data, agpsType, apn, bearerType);
+
+    EXIT_LOG(%d, ret_val);
+    return ret_val;
+}
+
+/*===========================================================================
+FUNCTION    loc_agps_open_with_apniptype
+
+DESCRIPTION
+   This function is called when on-demand data connection opening is successful.
+It should inform ARM 9 about the data open result.
+
+DEPENDENCIES
+   NONE
+
+RETURN VALUE
+   0
+
+SIDE EFFECTS
+   N/A
+
+===========================================================================*/
+static int  loc_agps_open_with_apniptype(const char* apn, ApnIpType apnIpType)
+{
+    ENTRY_LOG();
+    AGpsType agpsType = AGPS_TYPE_SUPL;
+    AGpsBearerType bearerType;
+
+    switch (apnIpType) {
+        case APN_IP_IPV4:
+            bearerType = AGPS_APN_BEARER_IPV4;
+            break;
+        case APN_IP_IPV6:
+            bearerType = AGPS_APN_BEARER_IPV6;
+            break;
+        case APN_IP_IPV4V6:
+            bearerType = AGPS_APN_BEARER_IPV4V6;
+            break;
+        default:
+            bearerType = AGPS_APN_BEARER_IPV4;
+            break;
+    }
+
     int ret_val = loc_eng_agps_open(loc_afw_data, agpsType, apn, bearerType);
 
     EXIT_LOG(%d, ret_val);


### PR DESCRIPTION
At the same time, change from AGpsInterface_v1 to AGpsInterface.
Fixes building and GPS also on these devices.

Thanks to @ganadist for the patch here:
https://gist.github.com/ganadist/75307f7d05defaa7d519ae87b148202a